### PR TITLE
fix: 🐛 send PAT as Basic auth password for git remote operations

### DIFF
--- a/src/main/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandler.java
+++ b/src/main/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandler.java
@@ -201,7 +201,7 @@ public class ChangeNotesSyncHandler implements CommandLineRunner {
    */
   private CredentialsProvider getCredentialsProvider(GitRepository gitRepository) {
     return gitRepository.isPatSet()
-        ? new UsernamePasswordCredentialsProvider(gitRepository.getPat(), "")
+        ? new UsernamePasswordCredentialsProvider("oauth2", gitRepository.getPat())
         : null;
   }
 

--- a/src/main/java/no/reliablesolutions/release_notes_portal/util/ReleaseNoteSyncHandler.java
+++ b/src/main/java/no/reliablesolutions/release_notes_portal/util/ReleaseNoteSyncHandler.java
@@ -205,7 +205,7 @@ public class ReleaseNoteSyncHandler {
       git.push()
         .setRemote("origin")
         .setRefSpecs(new RefSpec(getBranchNameForReleaseNote(releaseNote)))
-        .setCredentialsProvider(new UsernamePasswordCredentialsProvider(gitRepository.getPat(), ""))
+        .setCredentialsProvider(new UsernamePasswordCredentialsProvider("oauth2", gitRepository.getPat()))
         .call();
     } catch (Exception e) {
       throw new FailedSyncReleaseNoteException("Failed to push committed release note to remote Git repository", e);
@@ -255,7 +255,7 @@ public class ReleaseNoteSyncHandler {
 
         git.push()
           .setRefSpecs(refSpec)
-          .setCredentialsProvider(new UsernamePasswordCredentialsProvider(repoPair.key().getPat(), ""))
+          .setCredentialsProvider(new UsernamePasswordCredentialsProvider("oauth2", repoPair.key().getPat()))
           .setRemote("origin")
           .call(); //delete branch remotely
 


### PR DESCRIPTION
GitLab rejects tokens sent in the username field with an empty password. Use the conventional oauth2 username with the token as password, which GitHub, GitLab and Azure DevOps all accept.