### PR TITLE
fix: 🐛 walk only first-parent commits and read all change note files …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Dev first-run: copy `.env.example` → `.env`, fill it, then import `dev-realm.j
 Single-JAR deployment: the Vue build is copied into `src/main/resources/static/` and served by `SpaWebMvcConfig`. Root package `no.reliablesolutions.release_notes_portal`, layered `controller → service → domain/{entity,repository}`, with `config/` (security), `runner/` (startup sync), `util/` (git/YAML/AI helpers).
 
 ### Domain model
-- `ChangeNote` is central: optional `@ManyToOne` to `Product`/`Scope`/`Feature`/`Customer`, tied to a `GitRepository` + commit hash (unique per repo), flags `published`/`archived`/`viewableByEveryone`.
+- `ChangeNote` is central: optional `@ManyToOne` to `Product`/`Scope`/`Feature`/`Customer`, tied to a `GitRepository` + commit hash + note file path (unique per repo; a merge commit can yield several notes), flags `published`/`archived`/`viewableByEveryone`.
 - `ReleaseNote` owns a `@ManyToMany` to `ChangeNote`, an embedded `ReleaseTimeline`, and cascade-owned `ChangeImpact` children; flag `syncedToGit`.
 - `Prompt` rows (seeded by `data.sql`) hold the AI prompts, looked up by name ("Translation Prompt", "Change Notes Summary") — AI features break without seed data.
 

--- a/src/main/java/no/reliablesolutions/release_notes_portal/domain/entity/ChangeNote.java
+++ b/src/main/java/no/reliablesolutions/release_notes_portal/domain/entity/ChangeNote.java
@@ -23,8 +23,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-@Table(uniqueConstraints = @UniqueConstraint(name = "unique_git_commit_repository", columnNames = { "gitCommitHash",
-    "gitRepository_id" }))
+@Table(uniqueConstraints = @UniqueConstraint(name = "unique_git_commit_repository_file", columnNames = { "gitCommitHash",
+    "gitRepository_id", "gitFilePath" }))
 public class ChangeNote {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,6 +58,8 @@ public class ChangeNote {
   private Customer customer;
 
   private String gitCommitHash;
+
+  private String gitFilePath;
 
   private Instant gitCommitTimestamp;
 

--- a/src/main/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandler.java
+++ b/src/main/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryState;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevSort;
+import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
@@ -283,14 +284,15 @@ public class ChangeNotesSyncHandler implements CommandLineRunner {
     try (Git git = Git.open(repositoryDirectory);
     RevWalk revWalk = new RevWalk(git.getRepository());) {
       Repository repository = git.getRepository();
+      revWalk.setFirstParent(true); // walk only the first-parent chain of the branch; must be set before any commit is marked
+      revWalk.sort(RevSort.TOPO);
+      revWalk.sort(RevSort.REVERSE, true); // additive, keeps TOPO; sort commits from oldest to newest
       if (gitRepository.getLastCheckedCommitHash() != null) {
-        ObjectId lastCheckedCommitId = repository.resolve(gitRepository.getLastCheckedCommitHash()); 
-        RevCommit lastCheckedCommit = revWalk.parseCommit(lastCheckedCommitId);       
+        ObjectId lastCheckedCommitId = repository.resolve(gitRepository.getLastCheckedCommitHash());
+        RevCommit lastCheckedCommit = revWalk.parseCommit(lastCheckedCommitId);
         revWalk.markUninteresting(lastCheckedCommit); // only keep commits after the last checked commit
       }
       revWalk.markStart(revWalk.parseCommit(repository.resolve(Constants.HEAD)));
-      revWalk.sort(RevSort.TOPO);
-      revWalk.sort(RevSort.REVERSE); // sort commits from oldest to newest
       ObjectId lastCheckedCommitId = createChangeNotesFromCommits(revWalk, repositoryDirectory, repository, gitRepository);
       if (lastCheckedCommitId != null) {
         updateLastCheckedCommitHash(gitRepository, lastCheckedCommitId);
@@ -302,10 +304,10 @@ public class ChangeNotesSyncHandler implements CommandLineRunner {
   
   /**
    * Creates change notes from commits in a Git repository by checking for new change note files in the commits and creating change notes from those files.
-   * 
-   * If multiple change note files are found in the same commit, only the first one will be processed.
+   *
+   * Every matching added file in a commit produces its own change note, so a merge commit bringing in several change note files creates one change note per file.
    * The created change note entities are persisted in the database.
-   * 
+   *
    * @param revWalk the RevWalk to iterate over the commits, must not be null, must be ordered from oldest to newest
    * @param repositoryDirectory the local directory for the repository, must not be null
    * @param repository the JGit Repository object, must not be null
@@ -332,37 +334,34 @@ public class ChangeNotesSyncHandler implements CommandLineRunner {
       diffFormatter.setRepository(repository);
 
       for (RevCommit commit : revWalk) {
-        if (commit.getParentCount() == 0) {
-          logger.warn("No parent commit for commit {} with message '{}'. Skipping diff", commit.getName(), commit.getShortMessage());
-          continue;
+        RevTree parentTree = null; // a null parent tree diffs against the empty tree, so files in a root commit are included
+        if (commit.getParentCount() > 0) {
+          parentTree = revWalk.parseCommit(commit.getParent(0).getId()).getTree();
         }
-
-        RevCommit parentCommit = revWalk.parseCommit(commit.getParent(0).getId());
-        List<DiffEntry> diffEntries = diffFormatter.scan(parentCommit.getTree(), commit.getTree());
-        List<File> newChangeNoteFiles = diffEntries.stream()
+        List<DiffEntry> diffEntries = diffFormatter.scan(parentTree, commit.getTree());
+        List<String> newChangeNotePaths = diffEntries.stream()
           .filter(diffEntry -> diffEntry.getChangeType() == DiffEntry.ChangeType.ADD)
           .filter(diffEntry -> diffEntry.getNewPath().startsWith(gitRepository.getChangeNoteDirectory() + "/"))
           .filter(diffEntry -> diffEntry.getNewPath().endsWith(".yaml") || diffEntry.getNewPath().endsWith(".yml"))
-          .map(diffEntry -> new File(repositoryDirectory, diffEntry.getNewPath()))
+          .map(DiffEntry::getNewPath)
           .toList();
 
-        if (newChangeNoteFiles.isEmpty()) {
+        if (newChangeNotePaths.isEmpty()) {
           logger.debug("No new change note files found in commit {} with message '{}'", commit.getName(), commit.getShortMessage());
-        } else {
-          if (newChangeNoteFiles.size() > 1) {
-            logger.warn("Found multiple new change note files for commit {}: {}. Only the first will be processed", commit.getName(), newChangeNoteFiles.stream().map(File::getPath).toList());
-          }
-          File changeNoteFile = newChangeNoteFiles.get(0);
+        }
+        for (String changeNotePath : newChangeNotePaths) {
+          File changeNoteFile = new File(repositoryDirectory, changeNotePath);
           ChangeNote changeNote = getChangeNoteFromFile(changeNoteFile);
           if (changeNote != null) {
             changeNote.setGitRepository(gitRepository);
             changeNote.setGitCommitHash(commit.getName());
+            changeNote.setGitFilePath(changeNotePath); // repo-relative path, stable across clones
             changeNote.setGitCommitTimestamp(Instant.ofEpochSecond(commit.getCommitTime())); // git commit time is epoch seconds
             try {
               changeNoteService.updateChangeNote(changeNote);
-              logger.info("Created change note from file {} for commit {} in repository with id {}", changeNoteFile.getPath(), commit.getName(), gitRepository.getId());
+              logger.info("Created change note from file {} for commit {} in repository with id {}", changeNotePath, commit.getName(), gitRepository.getId());
             } catch (DataIntegrityViolationException e) {
-              logger.warn("Failed to create change note from file {} for commit {} in repository with id {} due to data integrity violation. This is likely caused by a duplicate git commit hash. Skipping this change note file", changeNoteFile.getPath(), commit.getName(), gitRepository.getId());
+              logger.warn("Failed to create change note from file {} for commit {} in repository with id {} due to data integrity violation. This is likely caused by an already imported change note for the same commit and file path. Skipping this change note file", changeNotePath, commit.getName(), gitRepository.getId());
             }
           }
         }

--- a/src/test/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandlerTest.java
+++ b/src/test/java/no/reliablesolutions/release_notes_portal/runner/ChangeNotesSyncHandlerTest.java
@@ -1,0 +1,206 @@
+package no.reliablesolutions.release_notes_portal.runner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.MergeCommand;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import no.reliablesolutions.release_notes_portal.domain.entity.ChangeNote;
+import no.reliablesolutions.release_notes_portal.domain.entity.GitRepository;
+import no.reliablesolutions.release_notes_portal.domain.repository.GitRepositoryRepository;
+import no.reliablesolutions.release_notes_portal.service.ChangeNoteService;
+import no.reliablesolutions.release_notes_portal.util.ChangeNoteFileHandler;
+
+class ChangeNotesSyncHandlerTest {
+
+  @TempDir
+  Path tempDir;
+
+  private GitRepositoryRepository gitRepositoryRepository;
+  private ChangeNoteService changeNoteService;
+  private ChangeNoteFileHandler changeNoteFileHandler;
+  private ChangeNotesSyncHandler handler;
+  private Path remoteDir;
+  private Path cloneDir;
+  private GitRepository gitRepository;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    gitRepositoryRepository = mock(GitRepositoryRepository.class);
+    changeNoteService = mock(ChangeNoteService.class);
+    changeNoteFileHandler = mock(ChangeNoteFileHandler.class);
+    when(changeNoteFileHandler.getChangeNoteFromFile(any(File.class))).thenAnswer(invocation -> new ChangeNote());
+    handler = new ChangeNotesSyncHandler(gitRepositoryRepository, changeNoteService, changeNoteFileHandler);
+
+    remoteDir = tempDir.resolve("remote");
+    cloneDir = tempDir.resolve("clone");
+    // Override the local path so the test clone stays inside the temp directory instead of git_repositories/<name>
+    gitRepository = new GitRepository() {
+      @Override
+      public String getLocalPath() {
+        return cloneDir.toString();
+      }
+    };
+    gitRepository.setName("sync-test-repo");
+    gitRepository.setUrl(remoteDir.toUri().toString());
+    gitRepository.setChangeNoteDirectory("notes");
+  }
+
+  private Git initRemote() throws Exception {
+    return Git.init().setDirectory(remoteDir.toFile()).setInitialBranch("main").call();
+  }
+
+  private RevCommit commitFiles(Git remote, String message, String... paths) throws Exception {
+    for (String path : paths) {
+      Path file = remoteDir.resolve(path);
+      Files.createDirectories(file.getParent());
+      Files.writeString(file, "change: Change from " + path);
+      remote.add().addFilepattern(path).call();
+    }
+    return remote.commit().setMessage(message)
+        .setAuthor("Test", "test@example.com").setCommitter("Test", "test@example.com").call();
+  }
+
+  private ObjectId mergeIntoMain(Git remote, String branch, String message) throws Exception {
+    remote.checkout().setName("main").call();
+    return remote.merge().include(remote.getRepository().resolve(branch))
+        .setFastForward(MergeCommand.FastForwardMode.NO_FF).setMessage(message).call().getNewHead();
+  }
+
+  @Test
+  void noteFileAddedOnMergedBranchCreatesExactlyOneChangeNote() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      remote.checkout().setCreateBranch(true).setName("feature").call();
+      commitFiles(remote, "add change note", "notes/feature-note.yaml");
+      remote.checkout().setName("main").call();
+      commitFiles(remote, "unrelated change on main", "src/Main.java");
+      ObjectId mergeCommitId = mergeIntoMain(remote, "feature", "merge feature into main");
+
+      handler.syncGitRepository(gitRepository);
+
+      ArgumentCaptor<ChangeNote> captor = ArgumentCaptor.forClass(ChangeNote.class);
+      verify(changeNoteService, times(1)).updateChangeNote(captor.capture());
+      assertEquals(mergeCommitId.getName(), captor.getValue().getGitCommitHash());
+      assertEquals("notes/feature-note.yaml", captor.getValue().getGitFilePath());
+    }
+  }
+
+  @Test
+  void mergeCommitWithMultipleNoteFilesCreatesOneChangeNotePerFile() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      remote.checkout().setCreateBranch(true).setName("feature").call();
+      commitFiles(remote, "add two change notes", "notes/a.yaml", "notes/b.yaml");
+      commitFiles(remote, "add another change note", "notes/c.yml");
+      ObjectId mergeCommitId = mergeIntoMain(remote, "feature", "merge feature into main");
+
+      handler.syncGitRepository(gitRepository);
+
+      ArgumentCaptor<ChangeNote> captor = ArgumentCaptor.forClass(ChangeNote.class);
+      verify(changeNoteService, times(3)).updateChangeNote(captor.capture());
+      assertEquals(Set.of(mergeCommitId.getName()),
+          captor.getAllValues().stream().map(ChangeNote::getGitCommitHash).collect(Collectors.toSet()));
+      assertEquals(Set.of("notes/a.yaml", "notes/b.yaml", "notes/c.yml"),
+          captor.getAllValues().stream().map(ChangeNote::getGitFilePath).collect(Collectors.toSet()));
+    }
+  }
+
+  @Test
+  void secondSyncOnlyProcessesCommitsAfterLastCheckedCommit() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      RevCommit firstNoteCommit = commitFiles(remote, "add first change note", "notes/one.yaml");
+
+      handler.syncGitRepository(gitRepository);
+
+      assertEquals(firstNoteCommit.getName(), gitRepository.getLastCheckedCommitHash());
+      RevCommit secondNoteCommit = commitFiles(remote, "add second change note", "notes/two.yaml");
+
+      handler.syncGitRepository(gitRepository);
+
+      ArgumentCaptor<ChangeNote> captor = ArgumentCaptor.forClass(ChangeNote.class);
+      verify(changeNoteService, times(2)).updateChangeNote(captor.capture());
+      assertEquals(secondNoteCommit.getName(), captor.getAllValues().get(1).getGitCommitHash());
+      assertEquals("notes/two.yaml", captor.getAllValues().get(1).getGitFilePath());
+      assertEquals(secondNoteCommit.getName(), gitRepository.getLastCheckedCommitHash());
+    }
+  }
+
+  @Test
+  void noteFileCommittedDirectlyToMainCreatesOneChangeNote() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      RevCommit noteCommit = commitFiles(remote, "add change note", "notes/direct.yaml");
+
+      handler.syncGitRepository(gitRepository);
+
+      ArgumentCaptor<ChangeNote> captor = ArgumentCaptor.forClass(ChangeNote.class);
+      verify(changeNoteService, times(1)).updateChangeNote(captor.capture());
+      assertEquals(noteCommit.getName(), captor.getValue().getGitCommitHash());
+      assertEquals("notes/direct.yaml", captor.getValue().getGitFilePath());
+      assertEquals(gitRepository, captor.getValue().getGitRepository());
+      assertNotNull(captor.getValue().getGitCommitTimestamp());
+    }
+  }
+
+  @Test
+  void commitsWithoutNoteFilesAdvanceLastCheckedCommit() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      RevCommit headCommit = commitFiles(remote, "unrelated change", "src/Main.java");
+
+      handler.syncGitRepository(gitRepository);
+
+      verify(changeNoteService, never()).updateChangeNote(any());
+      assertEquals(headCommit.getName(), gitRepository.getLastCheckedCommitHash());
+    }
+  }
+
+  @Test
+  void noteFileInRootCommitCreatesOneChangeNote() throws Exception {
+    try (Git remote = initRemote()) {
+      RevCommit rootCommit = commitFiles(remote, "initial commit with change note", "README.md", "notes/initial.yaml");
+
+      handler.syncGitRepository(gitRepository);
+
+      ArgumentCaptor<ChangeNote> captor = ArgumentCaptor.forClass(ChangeNote.class);
+      verify(changeNoteService, times(1)).updateChangeNote(captor.capture());
+      assertEquals(rootCommit.getName(), captor.getValue().getGitCommitHash());
+      assertEquals("notes/initial.yaml", captor.getValue().getGitFilePath());
+    }
+  }
+
+  @Test
+  void syncWithoutNewCommitsCreatesNothingAndKeepsLastCheckedCommit() throws Exception {
+    try (Git remote = initRemote()) {
+      commitFiles(remote, "initial commit", "README.md");
+      RevCommit noteCommit = commitFiles(remote, "add change note", "notes/only.yaml");
+
+      handler.syncGitRepository(gitRepository);
+      handler.syncGitRepository(gitRepository);
+
+      verify(changeNoteService, times(1)).updateChangeNote(any());
+      assertEquals(noteCommit.getName(), gitRepository.getLastCheckedCommitHash());
+    }
+  }
+}


### PR DESCRIPTION
…per commit

Walking every commit reachable from HEAD made change note files added on feature branches appear twice (branch commit + merge commit first-parent diff), creating duplicate change notes under different commit hashes. The walk now follows only the first-parent chain of the checked-out branch, so each merged branch's files are seen exactly once.

Every matching added file in a commit now produces its own change note instead of only the first, keyed by a new gitFilePath column widening the unique constraint to (commit hash, repository, file path). Root commits are diffed against the empty tree so their notes are imported too.